### PR TITLE
Apps targeting Android 12 and higher are required to specify an expli…

### DIFF
--- a/poolakey/src/main/AndroidManifest.xml
+++ b/poolakey/src/main/AndroidManifest.xml
@@ -8,7 +8,9 @@
     <uses-permission android:name="com.farsitel.bazaar.permission.PAY_THROUGH_BAZAAR" />
 
     <application>
-        <receiver android:name=".receiver.BillingReceiver">
+        <receiver android:name=".receiver.BillingReceiver"
+              android:exported="true"     
+                  >
             <intent-filter>
                 <action android:name="com.farsitel.bazaar.purchase" />
                 <action android:name="com.farsitel.bazaar.billingSupport" />


### PR DESCRIPTION
…cit value for `android: exported` when the corresponding component has an intent filter defined. See https://developer.android.com/guide/topics/manifest/activity-element#exported for details