### PR TITLE
Fixing empty callback bug

### DIFF
--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ServiceBillingConnection.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ServiceBillingConnection.kt
@@ -82,7 +82,11 @@ internal class ServiceBillingConnection(
                 }
             )?.let {
                 try {
-                    context.bindService(it, this, Context.BIND_AUTO_CREATE)
+                    val bindResult = context.bindService(it, this, Context.BIND_AUTO_CREATE)
+                    if (!bindResult){
+                        callback.connectionFailed.invoke(BazaarNotFoundException())
+                    }
+                    bindResult
                 } catch (e: SecurityException) {
                     callback.connectionFailed.invoke(e)
                     false


### PR DESCRIPTION
in newer versions of android sometimes without this check ( applied in the commit ), none of the callbacks works. this is because of a new policy applied to package visibility.

From the documentation:
> When an app targets Android 11 (API level 30) or higher and queries
> for information about the other apps that are installed on a device,
> the system filters this information by default. The limited package
> visibility reduces the number of apps that appear to be installed on a
> device, from your app's perspective. The limited app visibility
> affects the return results of methods that give information about
> other apps, such as queryIntentActivities(), getPackageInfo(), and
> getInstalledApplications(). The limited visibility also affects
> explicit interactions with other apps, such as starting another app's
> service.

basically, the app can not see the bazaar and connect to its services resulting in empty callbacks. a simple workaround is to ask the user to open the cafe-bazaar app and then come back to the app. 
I've also added 

    <queries>
            <package android:name="com.farsitel.bazaar" />
    </queries>

but it doesn't work. but for now, this will resolve the issue of empty callbacks. At least the user should know that the app can not find the cafe-bazaar app. 