### PR TITLE
Fix issue of call connection callback multiple times

### DIFF
--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/BillingConnection.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/BillingConnection.kt
@@ -2,8 +2,6 @@ package ir.cafebazaar.poolakey
 
 import android.app.Activity
 import android.content.Context
-import android.os.Build
-import android.os.Build.VERSION.SDK_INT
 import android.view.WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultRegistry
@@ -60,17 +58,24 @@ internal class BillingConnection(
             queryFunction
         )
 
-        val canConnect = serviceCommunicator.startConnection(context, requireNotNull(callback))
+        val serviceConnectRequestResult =
+            serviceCommunicator.startConnection(context, requireNotNull(callback))
 
-        billingCommunicator = if (canConnect) {
-            serviceCommunicator
-        } else {
-            receiverConnection.startConnection(
-                context,
-                requireNotNull(callback)
-            )
+        billingCommunicator = when {
+            serviceConnectRequestResult.canConnect -> serviceCommunicator
+            serviceConnectRequestResult.canUseFallback -> {
+                val receiverConnectRequestResult = receiverConnection.startConnection(
+                    context,
+                    requireNotNull(callback)
+                )
+                if (receiverConnectRequestResult.canConnect) {
+                    receiverConnection
+                } else {
+                    null
+                }
+            }
 
-            receiverConnection
+            else -> null
         }
         return requireNotNull(callback)
     }

--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/BillingConnection.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/BillingConnection.kt
@@ -90,7 +90,7 @@ internal class BillingConnection(
             onActivityResult(it, purchaseCallback)
         }.build()
 
-        purchaseRequest.cutoutModeIsShortEdges = if (SDK_INT >= Build.VERSION_CODES.P) {
+        purchaseRequest.cutoutModeIsShortEdges = if (isSdkPieAndUp()) {
             (context as? Activity)
                 ?.window
                 ?.attributes

--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/ConnectionRequestResult.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/ConnectionRequestResult.kt
@@ -1,0 +1,6 @@
+package ir.cafebazaar.poolakey
+
+internal data class ConnectionRequestResult(
+    val canConnect: Boolean,
+    val canUseFallback: Boolean = true
+)

--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/PackageManager.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/PackageManager.kt
@@ -2,6 +2,7 @@ package ir.cafebazaar.poolakey
 
 import android.content.Context
 import android.content.pm.PackageInfo
+import android.os.Build
 
 internal fun getPackageInfo(context: Context, packageName: String): PackageInfo? = try {
     val packageManager = context.packageManager
@@ -12,9 +13,13 @@ internal fun getPackageInfo(context: Context, packageName: String): PackageInfo?
 
 @Suppress("DEPRECATION")
 internal fun sdkAwareVersionCode(packageInfo: PackageInfo): Long {
-    return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+    return if (isSdkPieAndUp()) {
         packageInfo.longVersionCode
     } else {
         packageInfo.versionCode.toLong()
     }
 }
+
+internal fun isSdkNougatAndUp() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.N
+
+internal fun isSdkPieAndUp() = Build.VERSION.SDK_INT >= Build.VERSION_CODES.P

--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/BillingConnectionCommunicator.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/BillingConnectionCommunicator.kt
@@ -1,6 +1,7 @@
 package ir.cafebazaar.poolakey.billing.connection
 
 import android.content.Context
+import ir.cafebazaar.poolakey.ConnectionRequestResult
 import ir.cafebazaar.poolakey.PurchaseType
 import ir.cafebazaar.poolakey.PaymentLauncher
 import ir.cafebazaar.poolakey.billing.skudetail.SkuDetailFunctionRequest
@@ -18,7 +19,7 @@ internal interface BillingConnectionCommunicator {
     fun startConnection(
         context: Context,
         callback: ConnectionCallback
-    ): Boolean
+    ): ConnectionRequestResult
 
     fun consume(
         purchaseToken: String,

--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ReceiverBillingConnection.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ReceiverBillingConnection.kt
@@ -28,6 +28,7 @@ import ir.cafebazaar.poolakey.constant.BazaarIntent
 import ir.cafebazaar.poolakey.constant.BazaarIntent.REQUEST_SKU_DETAILS_LIST
 import ir.cafebazaar.poolakey.constant.Billing
 import ir.cafebazaar.poolakey.constant.Const.BAZAAR_PACKAGE_NAME
+import ir.cafebazaar.poolakey.exception.BazaarNotFoundException
 import ir.cafebazaar.poolakey.exception.BazaarNotSupportedException
 import ir.cafebazaar.poolakey.exception.ConsumeFailedException
 import ir.cafebazaar.poolakey.exception.DisconnectException
@@ -87,12 +88,13 @@ internal class ReceiverBillingConnection(
 
                 bazaarVersionCode > 0 -> {
                     callback.connectionFailed.invoke(BazaarNotSupportedException())
-                    ConnectionRequestResult(false)
+                    ConnectionRequestResult(canConnect = false, canUseFallback = false)
                 }
 
                 else -> ConnectionRequestResult(false)
             }
         }
+        callback.connectionFailed.invoke(BazaarNotFoundException())
         return ConnectionRequestResult(canConnect = false, canUseFallback = false)
     }
 

--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ServiceBillingConnection.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ServiceBillingConnection.kt
@@ -40,6 +40,7 @@ import ir.cafebazaar.poolakey.exception.BazaarNotFoundException
 import ir.cafebazaar.poolakey.exception.DisconnectException
 import ir.cafebazaar.poolakey.exception.IAPNotSupportedException
 import ir.cafebazaar.poolakey.exception.SubsNotSupportedException
+import ir.cafebazaar.poolakey.isSdkNougatAndUp
 import ir.cafebazaar.poolakey.request.PurchaseRequest
 import ir.cafebazaar.poolakey.security.Security
 import ir.cafebazaar.poolakey.takeIf
@@ -286,7 +287,7 @@ internal class ServiceBillingConnection(
     }
 
     private fun isServiceAvailableInDeepSleep(intent: Intent): Boolean {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+        return isSdkNougatAndUp() &&
                 context.packageManager
                     .queryIntentServices(intent, MATCH_DISABLED_COMPONENTS)
                     .isNotEmpty()

--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ServiceBillingConnection.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ServiceBillingConnection.kt
@@ -80,7 +80,7 @@ internal class ServiceBillingConnection(
                 thisIsTrue = ::isServiceAvailable,
                 andIfNot = {
                     callback.connectionFailed.invoke(BazaarNotFoundException())
-                    return ConnectionRequestResult(canConnect = false)
+                    return ConnectionRequestResult(canConnect = false, canUseFallback = false)
                 }
             )?.let {
                 return try {
@@ -91,6 +91,7 @@ internal class ServiceBillingConnection(
                 }
             }
         }
+        callback.connectionFailed.invoke(BazaarNotFoundException())
         return ConnectionRequestResult(canConnect = false, canUseFallback = false)
     }
 

--- a/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ServiceBillingConnection.kt
+++ b/poolakey/src/main/java/ir/cafebazaar/poolakey/billing/connection/ServiceBillingConnection.kt
@@ -6,12 +6,12 @@ import android.content.Intent
 import android.content.IntentSender
 import android.content.ServiceConnection
 import android.content.pm.PackageManager.MATCH_DISABLED_COMPONENTS
-import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import android.os.RemoteException
 import androidx.activity.result.IntentSenderRequest
 import com.android.vending.billing.IInAppBillingService
+import ir.cafebazaar.poolakey.ConnectionRequestResult
 import ir.cafebazaar.poolakey.ConnectionState
 import ir.cafebazaar.poolakey.PurchaseType
 import ir.cafebazaar.poolakey.PaymentLauncher
@@ -65,34 +65,32 @@ internal class ServiceBillingConnection(
     private var callbackReference: WeakReference<ConnectionCallback>? = null
     private var contextReference: WeakReference<Context>? = null
 
-    override fun startConnection(context: Context, callback: ConnectionCallback): Boolean {
+    override fun startConnection(
+        context: Context,
+        callback: ConnectionCallback
+    ): ConnectionRequestResult {
         callbackReference = WeakReference(callback)
         contextReference = WeakReference(context)
-
-        return Intent(BILLING_SERVICE_ACTION).apply {
-            `package` = BAZAAR_PACKAGE_NAME
-            setClassName(BAZAAR_PACKAGE_NAME, BAZAAR_PAYMENT_SERVICE_CLASS_NAME)
-        }
-            .takeIf(
+        if (Security.verifyBazaarIsInstalled(context)) {
+            Intent(BILLING_SERVICE_ACTION).apply {
+                `package` = BAZAAR_PACKAGE_NAME
+                setClassName(BAZAAR_PACKAGE_NAME, BAZAAR_PAYMENT_SERVICE_CLASS_NAME)
+            }.takeIf(
                 thisIsTrue = ::isServiceAvailable,
                 andIfNot = {
                     callback.connectionFailed.invoke(BazaarNotFoundException())
-                }
-            )?.takeIf(
-                thisIsTrue = {
-                    Security.verifyBazaarIsInstalled(context)
-                },
-                andIfNot = {
-                    callback.connectionFailed.invoke(BazaarNotFoundException())
+                    return ConnectionRequestResult(canConnect = false)
                 }
             )?.let {
-                try {
-                    context.bindService(it, this, Context.BIND_AUTO_CREATE)
+                return try {
+                    ConnectionRequestResult(context.bindService(it, this, Context.BIND_AUTO_CREATE))
                 } catch (e: SecurityException) {
                     callback.connectionFailed.invoke(e)
-                    false
+                    ConnectionRequestResult(false)
                 }
-            } ?: false
+            }
+        }
+        return ConnectionRequestResult(canConnect = false, canUseFallback = false)
     }
 
     override fun onServiceConnected(name: ComponentName?, service: IBinder?) {


### PR DESCRIPTION
#### Reference Issues/PRs 
None
#### What does this implement/fix?
**Some times payment connection callbacks trigered multiple times.** 
When we request a connection to the SDK, if the initial method of connection (service connection) fails, the callbacks are triggered. This means that the SDK is unable to connect to the market, and the app developer assumes that the connection request has failed and is completed. However, in the background, the SDK continues to attempt to connect using another method. Suddenly, another set of connection callbacks is triggered, which disrupts all the calculations made by the developer.
#### Any other comments?
No